### PR TITLE
Created index page that shows User model instances with fragment cache(which fails...)

### DIFF
--- a/app/assets/javascripts/users.coffee
+++ b/app/assets/javascripts/users.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,0 +1,13 @@
+// Place all the styles related to the Users controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/
+
+table {
+  table-layout: fixed;
+  border-collapse: collapse;
+}
+th, td {
+  border: 1px solid #555;
+  padding: 10px;
+  text-align: left;
+}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,5 @@
+class UsersController < ApplicationController
+  def index
+    @users = User.all
+  end
+end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,6 @@
+class User
+  include Mongoid::Document
+
+  field :email, type: String
+  field :name, type: String
+end

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,0 +1,18 @@
+<table>
+  <thead>
+    <tr>
+      <th>name</th>
+      <th>email</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @users.each do |user| %>
+      <% cache user do %>
+        <tr>
+          <td><%= user.name %></td>
+          <td><%= user.email %></td>
+        </tr>
+      <% end %>
+    <% end %>
+  </tbody>
+</table>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -26,6 +26,7 @@ Rails.application.configure do
 
     config.cache_store = :null_store
   end
+  config.action_controller.enable_fragment_cache_logging = true
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -1,0 +1,157 @@
+development:
+  # Configure available database clients. (required)
+  clients:
+    # Defines the default client. (required)
+    default:
+      # Defines the name of the default database that Mongoid can connect to.
+      # (required).
+      database: sample_app_mongoid_cache_development
+      # Provides the hosts the default client can connect to. Must be an array
+      # of host:port pairs. (required)
+      hosts:
+        - localhost:27017
+      options:
+        # Change the default write concern. (default = { w: 1 })
+        # write:
+        #   w: 1
+
+        # Change the default read preference. Valid options for mode are: :secondary,
+        # :secondary_preferred, :primary, :primary_preferred, :nearest
+        # (default: primary)
+        # read:
+        #   mode: :secondary_preferred
+        #   tag_sets:
+        #     - use: web
+
+        # The name of the user for authentication.
+        # user: 'user'
+
+        # The password of the user for authentication.
+        # password: 'password'
+
+        # The user's database roles.
+        # roles:
+        #   - 'dbOwner'
+
+        # Change the default authentication mechanism. Valid options are: :scram,
+        # :mongodb_cr, :mongodb_x509, and :plain. Note that all authentication
+        # mechanisms require username and password, with the exception of :mongodb_x509.
+        # Default on mongoDB 3.0 is :scram, default on 2.4 and 2.6 is :plain.
+        # auth_mech: :scram
+
+        # The database or source to authenticate the user against.
+        # (default: the database specified above or admin)
+        # auth_source: admin
+
+        # Force a the driver cluster to behave in a certain manner instead of auto-
+        # discovering. Can be one of: :direct, :replica_set, :sharded. Set to :direct
+        # when connecting to hidden members of a replica set.
+        # connect: :direct
+
+        # Changes the default time in seconds the server monitors refresh their status
+        # via ismaster commands. (default: 10)
+        # heartbeat_frequency: 10
+
+        # The time in seconds for selecting servers for a near read preference. (default: 0.015)
+        # local_threshold: 0.015
+
+        # The timeout in seconds for selecting a server for an operation. (default: 30)
+        # server_selection_timeout: 30
+
+        # The maximum number of connections in the connection pool. (default: 5)
+        # max_pool_size: 5
+
+        # The minimum number of connections in the connection pool. (default: 1)
+        # min_pool_size: 1
+
+        # The time to wait, in seconds, in the connection pool for a connection
+        # to be checked in before timing out. (default: 5)
+        # wait_queue_timeout: 5
+
+        # The time to wait to establish a connection before timing out, in seconds.
+        # (default: 5)
+        # connect_timeout: 5
+
+        # The timeout to wait to execute operations on a socket before raising an error.
+        # (default: 5)
+        # socket_timeout: 5
+
+        # The name of the replica set to connect to. Servers provided as seeds that do
+        # not belong to this replica set will be ignored.
+        # replica_set: name
+
+        # Whether to connect to the servers via ssl. (default: false)
+        # ssl: true
+
+        # The certificate file used to identify the connection against MongoDB.
+        # ssl_cert: /path/to/my.cert
+
+        # The private keyfile used to identify the connection against MongoDB.
+        # Note that even if the key is stored in the same file as the certificate,
+        # both need to be explicitly specified.
+        # ssl_key: /path/to/my.key
+
+        # A passphrase for the private key.
+        # ssl_key_pass_phrase: password
+
+        # Whether or not to do peer certification validation. (default: true)
+        # ssl_verify: true
+
+        # The file containing a set of concatenated certification authority certifications
+        # used to validate certs passed from the other end of the connection.
+        # ssl_ca_cert: /path/to/ca.cert
+
+
+  # Configure Mongoid specific options. (optional)
+  options:
+    # Includes the root model name in json serialization. (default: false)
+    # include_root_in_json: false
+
+    # Include the _type field in serialization. (default: false)
+    # include_type_for_serialization: false
+
+    # Preload all models in development, needed when models use
+    # inheritance. (default: false)
+    # preload_models: false
+
+    # Raise an error when performing a #find and the document is not found.
+    # (default: true)
+    # raise_not_found_error: true
+
+    # Raise an error when defining a scope with the same name as an
+    # existing method. (default: false)
+    # scope_overwrite_exception: false
+
+    # Raise an error when defining a field with the same name as an
+    # existing method. (default: false)
+    # duplicate_fields_exception: false
+
+    # Use Active Support's time zone in conversions. (default: true)
+    # use_activesupport_time_zone: true
+
+    # Ensure all times are UTC in the app side. (default: false)
+    # use_utc: false
+
+    # Set the Mongoid and Ruby driver log levels when not in a Rails
+    # environment. The Mongoid logger will be set to the Rails logger
+    # otherwise.(default: :info)
+    # log_level: :info
+
+    # Control whether `belongs_to` association is required. By default
+    # `belongs_to` will trigger a validation error if the association
+    # is not present. (default: true)
+    # belongs_to_required_by_default: true
+
+    # Application name that is printed to the mongodb logs upon establishing a
+    # connection in server versions >= 3.4. Note that the name cannot exceed 128 bytes.
+    # app_name: MyApplicationName
+test:
+  clients:
+    default:
+      database: sample_app_mongoid_cache_test
+      hosts:
+        - localhost:27017
+      options:
+        read:
+          mode: :primary
+        max_pool_size: 1

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -9,7 +9,7 @@ threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port        ENV.fetch("PORT") { 3000 }
+port        ENV.fetch("PORT") { 3333 }
 
 # Specifies the `environment` that Puma will run in.
 #

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  root to: 'users#index'
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class UsersControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class UserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# summary
Created an index page that simply renders User model instances with fragment cache enabled. But it caused `SystemStackError (stack level too deep)` when probably parsing cache keys of the instances internally in ActiveSupport. Still need to dig into it a bit more to see if something is not working properly inside Rails or simply Mongoid is not compatible enough with Rails5.2 atw.
### model
```
class User
  include Mongoid::Document

  field :email, type: String
  field :name, type: String
end
```

### controller
```
class UsersController < ApplicationController
  def index
    @users = User.all
  end
end
```

### view
```
<table>
  <thead>
    <tr>
      <th>name</th>
      <th>email</th>
    </tr>
  </thead>
  <tbody>
    <% @users.each do |user| %>
      <% cache user do %>
        <tr>
          <td><%= user.name %></td>
          <td><%= user.email %></td>
        </tr>
      <% end %>
    <% end %>
  </tbody>
</table>
```
https://guides.rubyonrails.org/caching_with_rails.html#fragment-caching


### stacktrace
```
Started GET "/" for 127.0.0.1 at 2018-08-01 23:59:06 +0900
Processing by UsersController#index as HTML
  Rendering users/index.html.erb within layouts/application
MONGODB | EVENT: #<Mongo::Monitoring::Event::TopologyOpening topology=Unknown>
MONGODB | Topology type 'unknown' initializing.
MONGODB | EVENT: #<Mongo::Monitoring::Event::ServerOpening address=localhost:27017 topology=Unknown>
MONGODB | Server localhost:27017 initializing.
MONGODB | EVENT: #<Mongo::Monitoring::Event::TopologyChanged prev=Unknown new=Single>
MONGODB | Topology type 'unknown' changed to type 'single'.
MONGODB | EVENT: #<Mongo::Monitoring::Event::ServerDescriptionChanged>
MONGODB | Server description for localhost:27017 changed from 'unknown' to 'standalone'.
MONGODB | EVENT: #<Mongo::Monitoring::Event::TopologyChanged prev=Single new=Single>
MONGODB | There was a change in the members of the 'single' topology.
MONGODB | localhost:27017 | sample_app_mongoid_cache_development.find | STARTED | {"find"=>"users", "filter"=>{}}
MONGODB | localhost:27017 | sample_app_mongoid_cache_development.find | SUCCEEDED | 0.007s
Read fragment views/users/index:5bb9c14e255656db576fb60bfc3138ac/users/5b61c8b34cfad12270b6689a (15.8ms)
  Rendered users/index.html.erb within layouts/application (41.1ms)
Completed 500 Internal Server Error in 84ms



SystemStackError (stack level too deep):

app/views/users/index.html.erb:10:in `block in _app_views_users_index_html_erb___4253829445550396588_70166155779880'
app/views/users/index.html.erb:9:in `_app_views_users_index_html_erb___4253829445550396588_70166155779880'
^C/Users/basicinc/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/web-console-3.6.2/lib/web_console/middleware.rb:20: [BUG] vm_call_cfunc - cfp consistency error
ruby 2.3.3p222 (2016-11-21 revision 56859) [x86_64-darwin15]
```